### PR TITLE
Apply the settings at index creation because AWS doesn't support _close

### DIFF
--- a/config/schema.json
+++ b/config/schema.json
@@ -1,13 +1,22 @@
 {
   "properties": {
     "full_text": { 
-      "type": "text" 
-    }, 
+      "type": "text",
+      "analyzer": "phrase_analyzer",
+      "search_analyzer": "keyword_analyzer",
+      "search_quote_analyzer": "phrase_analyzer"
+  }, 
     "all_titles": {
-        "type": "text"
+        "type": "text",
+      "analyzer": "phrase_analyzer",
+      "search_analyzer": "keyword_analyzer",
+      "search_quote_analyzer": "phrase_analyzer"
     },
     "all_subjects": {
-      "type": "text"
+      "type": "text",
+      "analyzer": "phrase_analyzer",
+      "search_analyzer": "keyword_analyzer",
+      "search_quote_analyzer": "phrase_analyzer"
     }
   },
   "dynamic_templates": [
@@ -29,6 +38,9 @@
         "match": "^date",
         "mapping": {
           "type": "text",
+          "analyzer": "phrase_analyzer",
+          "search_analyzer": "keyword_analyzer",
+          "search_quote_analyzer": "phrase_analyzer",
           "fields": {
             "keyword": { "type": "keyword" }
           }
@@ -52,6 +64,9 @@
         "path_match": "subject.label",
         "mapping": {
           "type": "text",
+          "analyzer": "phrase_analyzer",
+          "search_analyzer": "keyword_analyzer",
+          "search_quote_analyzer": "phrase_analyzer",
           "copy_to": [
             "full_text",
             "all_subjects"
@@ -67,6 +82,9 @@
         "path_match": "title.*",
         "mapping": {
           "type": "text",
+          "analyzer": "phrase_analyzer",
+          "search_analyzer": "keyword_analyzer",
+          "search_quote_analyzer": "phrase_analyzer",
           "fields": {
             "keyword": { "type": "keyword" }
           },
@@ -79,6 +97,9 @@
         "path_match": "*.title",
         "mapping": {
           "type": "text",
+          "analyzer": "phrase_analyzer",
+          "search_analyzer": "keyword_analyzer",
+          "search_quote_analyzer": "phrase_analyzer",
           "fields": {
             "keyword": { "type": "keyword" }
           },
@@ -91,6 +112,9 @@
         "path_match": "*.label",
         "mapping": {
           "type": "text",
+          "analyzer": "phrase_analyzer",
+          "search_analyzer": "keyword_analyzer",
+          "search_quote_analyzer": "phrase_analyzer",
           "fields": {
             "keyword": { "type": "keyword" }
           },
@@ -103,6 +127,9 @@
         "match_mapping_type": "string",
         "mapping": {
           "type": "text",
+          "analyzer": "phrase_analyzer",
+          "search_analyzer": "keyword_analyzer",
+          "search_quote_analyzer": "phrase_analyzer",
           "fields": {
             "keyword": {
               "type": "keyword",

--- a/config/settings.json
+++ b/config/settings.json
@@ -25,15 +25,5 @@
         }
       }
     }
-  },
-  "mappings": {
-    "properties": {
-      "title": {
-        "type": "text",
-        "analyzer": "phrase_analyzer",
-        "search_analyzer": "keyword_analyzer",
-        "search_quote_analyzer": "phrase_analyzer"
-      }
-    }
   }
 }

--- a/lib/common_indexer.rb
+++ b/lib/common_indexer.rb
@@ -33,7 +33,6 @@ module CommonIndexer # :nodoc:
     def configure_index!
       new_index = [index_name, Time.now.utc.strftime('%Y%m%d%H%M%S%3N')].join('_')
       create_index(new_index)
-      apply_settings(new_index)
       reindex_into(new_index) if client.indices.exists(index: index_name)
       client.indices.put_alias(index: new_index, name: index_name)
     end
@@ -41,14 +40,8 @@ module CommonIndexer # :nodoc:
     private
 
       def create_index(new_index)
-        client.indices.create(index: new_index)
+        client.indices.create(index: new_index, body: config.settings)
         client.indices.put_mapping(index: new_index, type: '_doc', body: { _doc: config.schema })
-      end
-
-      def apply_settings(new_index)
-        client.indices.close(index: new_index)
-        client.indices.put_settings(index: new_index, body: config.settings)
-        client.indices.open(index: new_index)
       end
 
       def reindex_into(new_index)

--- a/lib/common_indexer/version.rb
+++ b/lib/common_indexer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CommonIndexer
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end


### PR DESCRIPTION
`v0.5.0` created the index first, then closed it to apply the new analyzer settings. It turns out that, for reasons no one has adequately explained, AWS ElasticSearch [doesn't support the `_close` and `_open` resources](https://forums.aws.amazon.com/message.jspa?messageID=683415). The workaround is to apply the analysis settings when the index is created.

This change also applies the correct analyzers to dynamic field mappings.